### PR TITLE
[OPUS] Use only specialized header X-Skyflow-Authorization for authorize outbound connection

### DIFF
--- a/src/VirtoCommerce.Skyflow.Data/Services/SkyflowAuthorizationHandler.cs
+++ b/src/VirtoCommerce.Skyflow.Data/Services/SkyflowAuthorizationHandler.cs
@@ -33,6 +33,7 @@ namespace VirtoCommerce.Skyflow.Data.Services
         private async Task SetHeadersAsync(HttpRequestMessage request)
         {
             var token = await _skyflowClient.GetBearerToken(_options.IntegrationsAccount);
+            request.Headers.Add("Authorization", $"Bearer {token.AccessToken}");
             request.Headers.Add("X-Skyflow-Authorization", token.AccessToken);
             request.Headers.Add("User-Agent", "VirtoCommerce/1.0");
         }

--- a/src/VirtoCommerce.Skyflow.Data/Services/SkyflowAuthorizationHandler.cs
+++ b/src/VirtoCommerce.Skyflow.Data/Services/SkyflowAuthorizationHandler.cs
@@ -33,7 +33,6 @@ namespace VirtoCommerce.Skyflow.Data.Services
         private async Task SetHeadersAsync(HttpRequestMessage request)
         {
             var token = await _skyflowClient.GetBearerToken(_options.IntegrationsAccount);
-            request.Headers.Add("Authorization", $"Bearer {token.AccessToken}");
             request.Headers.Add("X-Skyflow-Authorization", token.AccessToken);
             request.Headers.Add("User-Agent", "VirtoCommerce/1.0");
         }

--- a/src/VirtoCommerce.Skyflow.Data/Services/SkyflowAuthorizationHandler.cs
+++ b/src/VirtoCommerce.Skyflow.Data/Services/SkyflowAuthorizationHandler.cs
@@ -35,7 +35,7 @@ namespace VirtoCommerce.Skyflow.Data.Services
             var token = await _skyflowClient.GetBearerToken(_options.IntegrationsAccount);
             request.Headers.Add("Authorization", $"Bearer {token.AccessToken}");
             request.Headers.Add("X-Skyflow-Authorization", token.AccessToken);
-            request.Headers.Add("User-Agent", "VirtoCommerce/1.0");
+            request.Headers.Add("User-Agent", "VirtoCommerce/3.0");
         }
     }
 }

--- a/src/VirtoCommerce.Skyflow.Data/Services/SkyflowClient.cs
+++ b/src/VirtoCommerce.Skyflow.Data/Services/SkyflowClient.cs
@@ -136,7 +136,7 @@ public class SkyflowClient(
         {
             message.Headers.Add("Authorization", $"Bearer {token.AccessToken}");
         }
-        message.Headers.Add("User-Agent", "VirtoCommerce/1.0");
+        message.Headers.Add("User-Agent", "VirtoCommerce/3.0");
 
         var response = await httpClient.SendAsync(message);
         return response;

--- a/src/VirtoCommerce.Skyflow.Data/Services/SkyflowClient.cs
+++ b/src/VirtoCommerce.Skyflow.Data/Services/SkyflowClient.cs
@@ -64,7 +64,7 @@ public class SkyflowClient(
         {
             request.Headers.Add(header.Key, header.Value);
         }
-        var response = await Send(request);
+        var response = await Send(request, "X-Skyflow-Authorization");
         return response;
     }
 
@@ -123,9 +123,14 @@ public class SkyflowClient(
         return result;
     }
 
-    private async Task<HttpResponseMessage> Send(HttpRequestMessage message)
+    private async Task<HttpResponseMessage> Send(HttpRequestMessage message, string authHeader = "Authorization")
     {
-        var httpClient = httpClientFactory.CreateClient(ModuleConstants.SkyflowHttpClientName);
+        var httpClient = httpClientFactory.CreateClient();
+
+        var token = await GetBearerToken(_options.IntegrationsAccount);
+        message.Headers.Add(authHeader, token.AccessToken);
+        message.Headers.Add("User-Agent", "VirtoCommerce/1.0");
+
         var response = await httpClient.SendAsync(message);
         return response;
     }

--- a/src/VirtoCommerce.Skyflow.Data/Services/SkyflowClient.cs
+++ b/src/VirtoCommerce.Skyflow.Data/Services/SkyflowClient.cs
@@ -64,7 +64,7 @@ public class SkyflowClient(
         {
             request.Headers.Add(header.Key, header.Value);
         }
-        var response = await Send(request, "X-Skyflow-Authorization");
+        var response = await Send(request, useConnectionAuthHeader: true);
         return response;
     }
 
@@ -123,12 +123,19 @@ public class SkyflowClient(
         return result;
     }
 
-    private async Task<HttpResponseMessage> Send(HttpRequestMessage message, string authHeader = "Authorization")
+    private async Task<HttpResponseMessage> Send(HttpRequestMessage message, bool useConnectionAuthHeader = false)
     {
         var httpClient = httpClientFactory.CreateClient();
 
         var token = await GetBearerToken(_options.IntegrationsAccount);
-        message.Headers.Add(authHeader, token.AccessToken);
+        if (useConnectionAuthHeader)
+        {
+            message.Headers.Add("X-Skyflow-Authorization", token.AccessToken);
+        }
+        else
+        {
+            message.Headers.Add("Authorization", $"Bearer {token.AccessToken}");
+        }
         message.Headers.Add("User-Agent", "VirtoCommerce/1.0");
 
         var response = await httpClient.SendAsync(message);


### PR DESCRIPTION
Currently, we send two headers for each outbound request: Authorization and X-Skyflow-Authorization. However, if you need to send the Authorization header to the original upstream service, the Authorization header will override it. To avoid this issue, the code has been changed to use only the specialized X-Skyflow-Authorization header for authorizing outbound connections

## Description

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-1983

### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Skyflow_3.807.0-pr-11-2e6f.zip