### PR TITLE
VCST-2023: fix method to get cards list

### DIFF
--- a/src/VirtoCommerce.Skyflow.XApi/Queries/SkyflowCardQueryHandler.cs
+++ b/src/VirtoCommerce.Skyflow.XApi/Queries/SkyflowCardQueryHandler.cs
@@ -1,8 +1,6 @@
-using Microsoft.IdentityModel.Tokens;
-using VirtoCommerce.Xapi.Core.Infrastructure;
-using VirtoCommerce.PaymentModule.Core.Services;
-using VirtoCommerce.Platform.Core.Settings;
+using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Skyflow.Core.Services;
+using VirtoCommerce.Xapi.Core.Infrastructure;
 
 namespace VirtoCommerce.Skyflow.XApi.Queries;
 


### PR DESCRIPTION
## Description

use the correct method to check string.

The extension method `IsNullOrEmpty` was used from the `Microsoft.IdentityModel.Tokens` namespace
Now it is from the `VirtoCommerce.Platform.Core.Common`

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-2023
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Skyflow_3.808.0-pr-12-3172.zip