### PR TITLE
VCST-5009: Extend Skyflow with AllowCartPayment

### DIFF
--- a/src/VirtoCommerce.Skyflow.Data/Providers/SkyflowPaymentMethod.cs
+++ b/src/VirtoCommerce.Skyflow.Data/Providers/SkyflowPaymentMethod.cs
@@ -49,9 +49,11 @@ namespace VirtoCommerce.Skyflow.Data.Providers
                     {"tableName", _options.TableName}
                 }
             };
-            var payment = (PaymentIn)request.Payment;
-            payment.PaymentStatus = PaymentStatus.Pending;
-            payment.Status = payment.PaymentStatus.ToString();
+            if (request.Payment is PaymentIn payment)
+            {
+                payment.PaymentStatus = PaymentStatus.Pending;
+                payment.Status = payment.PaymentStatus.ToString();
+            }
 
             return result;
         }
@@ -122,6 +124,7 @@ namespace VirtoCommerce.Skyflow.Data.Providers
             });
         }
 
+        public override bool AllowCartPayment => true;
         public override PaymentMethodType PaymentMethodType => PaymentMethodType.PreparedForm;
         public override PaymentMethodGroupType PaymentMethodGroupType => PaymentMethodGroupType.Alternative;
     }


### PR DESCRIPTION
## Description

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5009
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Skyflow_3.1002.0-pr-23-5a1b.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small payment-provider tweaks with a defensive null/type check; no auth, vault, or gateway routing changes.
> 
> **Overview**
> Enables **Skyflow** as a payment option during **cart checkout** by overriding `AllowCartPayment` to return `true` on `SkyflowPaymentMethod`.
> 
> In `ProcessPaymentAsync`, payment status is now updated only when `request.Payment` is a `PaymentIn` (pattern match), instead of always casting to `PaymentIn`, so non–`PaymentIn` payment objects no longer throw at process time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a1b6057ac138a84448c666b8f6bce6dddb8f466. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->