### PR TITLE
VCST-5468: Resolve mediators per request

### DIFF
--- a/src/VirtoCommerce.Skyflow.Web/module.manifest
+++ b/src/VirtoCommerce.Skyflow.Web/module.manifest
@@ -8,7 +8,7 @@
   <dependencies>
     <dependency id="VirtoCommerce.Orders" version="3.1000.0" />
     <dependency id="VirtoCommerce.Payment" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Xapi" version="3.1000.0" />
+    <dependency id="VirtoCommerce.Xapi" version="3.1015.0" />
   </dependencies>
 
   <title>Skyflow</title>

--- a/src/VirtoCommerce.Skyflow.XApi/Commands/DeleteSkyflowCardCommandBuilder.cs
+++ b/src/VirtoCommerce.Skyflow.XApi/Commands/DeleteSkyflowCardCommandBuilder.cs
@@ -1,3 +1,4 @@
+using System;
 using GraphQL;
 using GraphQL.Types;
 using MediatR;
@@ -7,10 +8,15 @@ using VirtoCommerce.Xapi.Core.Extensions;
 
 namespace VirtoCommerce.Skyflow.XApi.Commands;
 
-public class DeleteSkyflowCardCommandBuilder(IMediator mediator,
-        IAuthorizationService authorizationService
-        ) : CommandBuilder<DeleteSkyflowCardCommand, bool, DeleteSkyflowCardCommandType, BooleanGraphType>(mediator, authorizationService)
+public class DeleteSkyflowCardCommandBuilder(IAuthorizationService authorizationService)
+    : CommandBuilder<DeleteSkyflowCardCommand, bool, DeleteSkyflowCardCommandType, BooleanGraphType>(authorizationService)
 {
+    [Obsolete("Use the constructor without IMediator. The mediator is resolved from context.RequestServices per request.", DiagnosticId = "VC0015", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
+    public DeleteSkyflowCardCommandBuilder(IMediator mediator, IAuthorizationService authorizationService)
+        : this(authorizationService)
+    {
+    }
+
     protected override string Name => "DeleteSkyflowCard";
 
     protected override Task BeforeMediatorSend(IResolveFieldContext<object> context, DeleteSkyflowCardCommand request)
@@ -22,6 +28,7 @@ public class DeleteSkyflowCardCommandBuilder(IMediator mediator,
     {
         var result = base.GetRequest(context);
         result.UserId = context.GetCurrentUserId();
+
         return result;
     }
 }

--- a/src/VirtoCommerce.Skyflow.XApi/Queries/SkyflowCardQueryBuilder.cs
+++ b/src/VirtoCommerce.Skyflow.XApi/Queries/SkyflowCardQueryBuilder.cs
@@ -1,16 +1,19 @@
+using System;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
-using VirtoCommerce.Xapi.Core.BaseQueries;
 using VirtoCommerce.Skyflow.XApi.Schemas;
+using VirtoCommerce.Xapi.Core.BaseQueries;
 
 namespace VirtoCommerce.Skyflow.XApi.Queries;
 
-public class SkyflowCardQueryBuilder : QueryBuilder<SkyflowCardQuery, SkyflowCardResponse, SkyflowCardResponseType>
+public class SkyflowCardQueryBuilder(IAuthorizationService authorizationService)
+    : QueryBuilder<SkyflowCardQuery, SkyflowCardResponse, SkyflowCardResponseType>(authorizationService)
 {
-    protected override string Name => "SkyflowCards";
-
+    [Obsolete("Use the constructor without IMediator. The mediator is resolved from context.RequestServices per request.", DiagnosticId = "VC0015", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
     public SkyflowCardQueryBuilder(IMediator mediator, IAuthorizationService authorizationService)
-        : base(mediator, authorizationService)
+        : this(authorizationService)
     {
     }
+
+    protected override string Name => "SkyflowCards";
 }

--- a/src/VirtoCommerce.Skyflow.XApi/VirtoCommerce.Skyflow.XApi.csproj
+++ b/src/VirtoCommerce.Skyflow.XApi/VirtoCommerce.Skyflow.XApi.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.1000.0" />
+    <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.1015.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.Skyflow.Core\VirtoCommerce.Skyflow.Core.csproj" />


### PR DESCRIPTION
## Summary

- migrate Skyflow GraphQL command and query builders to the request-scoped XApi mediator contract
- align the XApi package and module manifest dependency to 3.1015

## Why

GraphQL builders are singletons. Resolving `IMediator` from `context.RequestServices` for each operation preserves request-scoped dependency lifetimes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, pattern-aligned DI change with obsolete constructors preserved; no new auth or payment logic in the diff.
> 
> **Overview**
> Aligns Skyflow’s GraphQL **command** and **query** builders with **XApi 3.1015**, where singleton builders no longer take `IMediator` and the base types resolve it from `context.RequestServices` on each operation.
> 
> `DeleteSkyflowCardCommandBuilder` and `SkyflowCardQueryBuilder` now use primary constructors that only inject `IAuthorizationService`; the previous `IMediator` constructors remain as **obsolete** (VC0015) shims. `VirtoCommerce.Xapi.Core` and the module’s `VirtoCommerce.Xapi` dependency are bumped to **3.1015.0** to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6f66f80542038375b5acc47a3201b82f6311e31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5468
Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Skyflow_3.1004.0-alpha.81-vcst-5468.zip