### PR TITLE
VCST-5720: Expose the module GraphQL schema on its own endpoint

### DIFF
--- a/src/VirtoCommerce.Skyflow.Web/Module.cs
+++ b/src/VirtoCommerce.Skyflow.Web/Module.cs
@@ -12,6 +12,7 @@ using VirtoCommerce.Skyflow.Data.Providers;
 using VirtoCommerce.Skyflow.Data.Services;
 using VirtoCommerce.Skyflow.XApi;
 using VirtoCommerce.Xapi.Core.Extensions;
+using VirtoCommerce.Xapi.Core.Infrastructure;
 
 namespace VirtoCommerce.Skyflow.Web;
 
@@ -26,6 +27,7 @@ public class Module : IModule, IHasConfiguration
         {
             builder.AddSchema(serviceCollection, typeof(AssemblyMarker));
         });
+        serviceCollection.AddSingleton<ScopedSchemaFactory<AssemblyMarker>>();
 
         serviceCollection.Configure<SkyflowOptions>(Configuration.GetSection("Payments:Skyflow"));
         serviceCollection.AddTransient<ISkyflowClient, SkyflowClient>();
@@ -38,6 +40,8 @@ public class Module : IModule, IHasConfiguration
 
     public void PostInitialize(IApplicationBuilder appBuilder)
     {
+        appBuilder.UseScopedSchema<AssemblyMarker>("skyflow");
+
         var paymentMethodsRegistrar = appBuilder.ApplicationServices.GetRequiredService<IPaymentMethodsRegistrar>();
         paymentMethodsRegistrar.RegisterPaymentMethod(() => appBuilder.ApplicationServices.GetService<SkyflowPaymentMethod>());
     }


### PR DESCRIPTION
Register ScopedSchemaFactory<AssemblyMarker> and map the module schema to /graphql/skyflow, following the pattern used by other xAPI modules.

## Description

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5720
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Skyflow_3.1005.0-pr-25-82f2.zip
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small DI and middleware wiring only; no changes to payment or Skyflow client behavior.
> 
> **Overview**
> The Skyflow xAPI module’s GraphQL schema is now served on its own route instead of only being built in DI.
> 
> During startup the module registers `ScopedSchemaFactory<AssemblyMarker>` and, in `PostInitialize`, calls `UseScopedSchema<AssemblyMarker>("skyflow")` so clients can hit **`/graphql/skyflow`**, matching other xAPI modules. Payment registration and existing Skyflow services are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82f2fd9458662b7e17ec33db6097aa826ac74c81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->